### PR TITLE
Add Helm chart NOTES on verification steps

### DIFF
--- a/helm-chart/kubeomatic-timebomb/templates/NOTES.txt
+++ b/helm-chart/kubeomatic-timebomb/templates/NOTES.txt
@@ -1,0 +1,4 @@
+Check the admission webhook pods with "kubectl get pods -n timebomb".
+Validate that mutating and validating webhook configurations exist.
+Extend expiration with tools/extend-timer-bash/run.sh or a kubectl patch.
+Review scheduler logs to confirm expired pods are deleted.


### PR DESCRIPTION
## Summary
- add post-install NOTES for the kubeomatic-timebomb chart

## Testing
- `mvn -q test -f timebomb-admission/pom.xml` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c19c75bbc8332a5880e074ee8ad55